### PR TITLE
feat: M-002 provider adapters and embeddings stub

### DIFF
--- a/docs/milestones/M-002.md
+++ b/docs/milestones/M-002.md
@@ -1,0 +1,33 @@
+# Milestone M-002
+
+## Source
+- Issue: #3
+- Area: area/router
+
+## Acceptance Criteria
+1. Provider adapter interfaces/registry exist for routing provider-specific implementations.
+2. `POST /v1/embeddings` stub returns OpenAI-compatible embeddings response shape for supported models.
+3. Unsupported provider/model and invalid payloads return HTTP 400 error payloads.
+4. Tests cover adapter registry behavior and `/v1/embeddings` route success/error cases.
+
+## Scope
+- In scope: provider adapter abstraction, default stub adapter, embeddings stub route, route/unit tests.
+- Out of scope: live provider API calls, auth, key management, streaming, production routing policy.
+
+## Test Plan
+- Unit: `test/provider-adapters.test.ts`.
+- Integration: `test/embeddings-route.test.ts`.
+- CI: `make test`, `make coverage`, `make ci`.
+
+## Verification Commands
+```bash
+make test
+make coverage
+make ci
+```
+
+## Status
+- [x] Implemented
+- [x] Tests added/updated
+- [x] Gates green
+- [ ] PR opened

--- a/openapi/mvp.yaml
+++ b/openapi/mvp.yaml
@@ -30,6 +30,50 @@ paths:
                       - chat
                 meta:
                   request_id: req_models_001
+  /v1/embeddings:
+    post:
+      summary: Create embeddings (stub)
+      operationId: createEmbeddings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmbeddingsRequest"
+            example:
+              model: openai/text-embedding-3-small
+              input:
+                - hello
+                - world
+      responses:
+        "200":
+          description: Embeddings created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmbeddingsResponse"
+              example:
+                object: list
+                data:
+                  - object: embedding
+                    embedding: [0.532, 0.05, 0.804124]
+                    index: 0
+                  - object: embedding
+                    embedding: [0.552, 0.05, 0.845361]
+                    index: 1
+                model: openai/text-embedding-3-small
+                usage:
+                  prompt_tokens: 3
+                  total_tokens: 3
+                x_router:
+                  provider: openai
+                  stub: true
+        "400":
+          description: Invalid request or unsupported model
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmbeddingsError"
   /api/keys:
     get:
       summary: List configured provider keys
@@ -120,6 +164,94 @@ components:
             $ref: "#/components/schemas/Model"
         meta:
           $ref: "#/components/schemas/Meta"
+    EmbeddingsRequest:
+      type: object
+      additionalProperties: false
+      required: [model, input]
+      properties:
+        model:
+          type: string
+          minLength: 1
+        input:
+          oneOf:
+            - type: string
+              minLength: 1
+            - type: array
+              minItems: 1
+              items:
+                type: string
+                minLength: 1
+    EmbeddingRow:
+      type: object
+      additionalProperties: false
+      required: [object, embedding, index]
+      properties:
+        object:
+          type: string
+          enum: [embedding]
+        embedding:
+          type: array
+          items:
+            type: number
+        index:
+          type: integer
+          minimum: 0
+    EmbeddingsUsage:
+      type: object
+      additionalProperties: false
+      required: [prompt_tokens, total_tokens]
+      properties:
+        prompt_tokens:
+          type: integer
+          minimum: 0
+        total_tokens:
+          type: integer
+          minimum: 0
+    EmbeddingsRouterMeta:
+      type: object
+      additionalProperties: false
+      required: [provider, stub]
+      properties:
+        provider:
+          type: string
+        stub:
+          type: boolean
+          enum: [true]
+    EmbeddingsResponse:
+      type: object
+      additionalProperties: false
+      required: [object, data, model, usage, x_router]
+      properties:
+        object:
+          type: string
+          enum: [list]
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/EmbeddingRow"
+        model:
+          type: string
+        usage:
+          $ref: "#/components/schemas/EmbeddingsUsage"
+        x_router:
+          $ref: "#/components/schemas/EmbeddingsRouterMeta"
+    EmbeddingsError:
+      type: object
+      additionalProperties: true
+      required: [error]
+      properties:
+        error:
+          type: object
+          additionalProperties: true
+          required: [code, message, request_id]
+          properties:
+            code:
+              type: string
+              enum: [INVALID_REQUEST, UNSUPPORTED_MODEL]
+            message:
+              type: string
+            request_id:
+              type: string
     ApiKeyRecord:
       type: object
       additionalProperties: false

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import Fastify from "fastify";
 import { z } from "zod";
+import { buildEmbeddingsStubResponse } from "./embeddings.js";
 import { buildModelsListResponse } from "./models-catalog.js";
 
 const healthzResponseSchema = z.object({
@@ -7,6 +8,22 @@ const healthzResponseSchema = z.object({
   service: z.literal("1router-api"),
   time: z.string().datetime()
 });
+
+function embeddingsErrorEnvelope(
+  requestId: string,
+  code: "INVALID_REQUEST" | "UNSUPPORTED_MODEL",
+  message: string,
+  details?: unknown
+) {
+  return {
+    error: {
+      code,
+      message,
+      request_id: requestId,
+      ...(details === undefined ? {} : { details })
+    }
+  };
+}
 
 export function buildApp() {
   const app = Fastify({ logger: false });
@@ -21,6 +38,26 @@ export function buildApp() {
 
   app.get("/v1/models", async () => {
     return buildModelsListResponse();
+  });
+
+  app.post("/v1/embeddings", async (request, reply) => {
+    try {
+      return await buildEmbeddingsStubResponse(request.body);
+    } catch (error) {
+      reply.header("x-request-id", request.id);
+
+      if (error instanceof z.ZodError) {
+        reply.code(400);
+        return embeddingsErrorEnvelope(request.id, "INVALID_REQUEST", "Invalid embeddings request", error.issues);
+      }
+
+      reply.code(400);
+      return embeddingsErrorEnvelope(
+        request.id,
+        "UNSUPPORTED_MODEL",
+        error instanceof Error ? error.message : "Unsupported embeddings model"
+      );
+    }
   });
 
   return app;

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import { buildDefaultProviderAdapterRegistry } from "./provider-adapters.js";
+
+export const embeddingsRequestSchema = z.object({
+  model: z.string().min(1),
+  input: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)])
+});
+
+export const embeddingsResponseSchema = z.object({
+  object: z.literal("list"),
+  data: z.array(
+    z.object({
+      object: z.literal("embedding"),
+      embedding: z.array(z.number()),
+      index: z.number().int().nonnegative()
+    })
+  ),
+  model: z.string(),
+  usage: z.object({
+    prompt_tokens: z.number().int().nonnegative(),
+    total_tokens: z.number().int().nonnegative()
+  }),
+  x_router: z.object({
+    provider: z.string(),
+    stub: z.literal(true)
+  })
+});
+
+export type EmbeddingsResponse = z.infer<typeof embeddingsResponseSchema>;
+
+const defaultRegistry = buildDefaultProviderAdapterRegistry();
+
+export async function buildEmbeddingsStubResponse(body: unknown): Promise<EmbeddingsResponse> {
+  const parsed = embeddingsRequestSchema.parse(body);
+  const adapter = defaultRegistry.resolveEmbeddingsAdapter(parsed.model);
+
+  if (!adapter) {
+    throw new Error(`No embeddings adapter available for model: ${parsed.model}`);
+  }
+
+  const result = await adapter.createEmbeddings(parsed);
+
+  return embeddingsResponseSchema.parse({
+    object: "list",
+    data: result.data.map((item) => ({
+      object: "embedding",
+      embedding: item.embedding,
+      index: item.index
+    })),
+    model: result.model,
+    usage: result.usage,
+    x_router: {
+      provider: result.provider,
+      stub: true
+    }
+  });
+}

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -21,6 +21,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/embeddings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create embeddings (stub) */
+        post: operations["createEmbeddings"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/keys": {
         parameters: {
             query?: never;
@@ -70,6 +87,45 @@ export interface components {
         ModelsListResponse: {
             data: components["schemas"]["Model"][];
             meta: components["schemas"]["Meta"];
+        };
+        EmbeddingsRequest: {
+            model: string;
+            input: string | string[];
+        };
+        EmbeddingRow: {
+            /** @enum {string} */
+            object: "embedding";
+            embedding: number[];
+            index: number;
+        };
+        EmbeddingsUsage: {
+            prompt_tokens: number;
+            total_tokens: number;
+        };
+        EmbeddingsRouterMeta: {
+            provider: string;
+            /** @enum {boolean} */
+            stub: true;
+        };
+        EmbeddingsResponse: {
+            /** @enum {string} */
+            object: "list";
+            data: components["schemas"]["EmbeddingRow"][];
+            model: string;
+            usage: components["schemas"]["EmbeddingsUsage"];
+            x_router: components["schemas"]["EmbeddingsRouterMeta"];
+        };
+        EmbeddingsError: {
+            error: {
+                /** @enum {string} */
+                code: "INVALID_REQUEST" | "UNSUPPORTED_MODEL";
+                message: string;
+                request_id: string;
+            } & {
+                [key: string]: unknown;
+            };
+        } & {
+            [key: string]: unknown;
         };
         ApiKeyRecord: {
             id: string;
@@ -150,6 +206,82 @@ export interface operations {
                      *     }
                      */
                     "application/json": components["schemas"]["ModelsListResponse"];
+                };
+            };
+        };
+    };
+    createEmbeddings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                /**
+                 * @example {
+                 *       "model": "openai/text-embedding-3-small",
+                 *       "input": [
+                 *         "hello",
+                 *         "world"
+                 *       ]
+                 *     }
+                 */
+                "application/json": components["schemas"]["EmbeddingsRequest"];
+            };
+        };
+        responses: {
+            /** @description Embeddings created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "object": "list",
+                     *       "data": [
+                     *         {
+                     *           "object": "embedding",
+                     *           "embedding": [
+                     *             0.532,
+                     *             0.05,
+                     *             0.804124
+                     *           ],
+                     *           "index": 0
+                     *         },
+                     *         {
+                     *           "object": "embedding",
+                     *           "embedding": [
+                     *             0.552,
+                     *             0.05,
+                     *             0.845361
+                     *           ],
+                     *           "index": 1
+                     *         }
+                     *       ],
+                     *       "model": "openai/text-embedding-3-small",
+                     *       "usage": {
+                     *         "prompt_tokens": 3,
+                     *         "total_tokens": 3
+                     *       },
+                     *       "x_router": {
+                     *         "provider": "openai",
+                     *         "stub": true
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["EmbeddingsResponse"];
+                };
+            };
+            /** @description Invalid request or unsupported model */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EmbeddingsError"];
                 };
             };
         };

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+export const embeddingsInputSchema = z.object({
+  model: z.string().min(1),
+  input: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)])
+});
+
+export type EmbeddingsInput = z.infer<typeof embeddingsInputSchema>;
+
+export type EmbeddingVector = number[];
+
+export type EmbeddingsProviderResult = {
+  provider: string;
+  model: string;
+  data: Array<{
+    embedding: EmbeddingVector;
+    index: number;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    total_tokens: number;
+  };
+};
+
+export interface ProviderAdapter {
+  readonly provider: string;
+  supportsEmbeddings(model: string): boolean;
+  createEmbeddings(request: EmbeddingsInput): Promise<EmbeddingsProviderResult>;
+}
+
+export class ProviderAdapterRegistry {
+  private readonly adapters = new Map<string, ProviderAdapter>();
+
+  register(adapter: ProviderAdapter) {
+    this.adapters.set(adapter.provider, adapter);
+  }
+
+  get(provider: string) {
+    return this.adapters.get(provider);
+  }
+
+  resolveEmbeddingsAdapter(model: string) {
+    const provider = model.split("/", 1)[0] ?? "";
+    const adapter = this.adapters.get(provider);
+
+    if (!adapter || !adapter.supportsEmbeddings(model)) {
+      return null;
+    }
+
+    return adapter;
+  }
+}
+
+function estimateTokens(inputs: string[]) {
+  const chars = inputs.reduce((sum, item) => sum + item.length, 0);
+  return Math.max(1, Math.ceil(chars / 4));
+}
+
+function stubEmbeddingForText(text: string) {
+  const bytes = Array.from(text).map((char) => char.charCodeAt(0));
+  const sum = bytes.reduce((acc, n) => acc + n, 0);
+  const len = Math.max(1, text.length);
+
+  return [Number((sum / 1000).toFixed(6)), Number((len / 100).toFixed(6)), Number(((sum % 97) / 97).toFixed(6))];
+}
+
+export class OpenAIStubProviderAdapter implements ProviderAdapter {
+  readonly provider = "openai";
+
+  supportsEmbeddings(model: string) {
+    return model.startsWith("openai/");
+  }
+
+  async createEmbeddings(request: EmbeddingsInput): Promise<EmbeddingsProviderResult> {
+    const parsed = embeddingsInputSchema.parse(request);
+    const inputs = Array.isArray(parsed.input) ? parsed.input : [parsed.input];
+
+    return {
+      provider: this.provider,
+      model: parsed.model,
+      data: inputs.map((value, index) => ({
+        embedding: stubEmbeddingForText(value),
+        index
+      })),
+      usage: {
+        prompt_tokens: estimateTokens(inputs),
+        total_tokens: estimateTokens(inputs)
+      }
+    };
+  }
+}
+
+export function buildDefaultProviderAdapterRegistry() {
+  const registry = new ProviderAdapterRegistry();
+  registry.register(new OpenAIStubProviderAdapter());
+  return registry;
+}

--- a/test/embeddings-route.test.ts
+++ b/test/embeddings-route.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildApp } from "../src/app.js";
+import { embeddingsResponseSchema } from "../src/embeddings.js";
+
+describe("POST /v1/embeddings", () => {
+  const app = buildApp();
+
+  beforeAll(async () => {
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("returns an OpenAI-compatible embeddings stub response", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/embeddings",
+      payload: {
+        model: "openai/text-embedding-3-small",
+        input: ["hello", "world"]
+      }
+    });
+
+    expect(res.statusCode).toBe(200);
+    const parsed = embeddingsResponseSchema.parse(res.json());
+
+    expect(parsed.object).toBe("list");
+    expect(parsed.data).toHaveLength(2);
+    expect(parsed.data[0]?.object).toBe("embedding");
+    expect(parsed.x_router).toEqual({ provider: "openai", stub: true });
+  });
+
+  it("returns 400 for invalid payloads", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/embeddings",
+      payload: {
+        model: "",
+        input: []
+      }
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.headers["x-request-id"]).toBeTruthy();
+    expect(res.json()).toMatchObject({
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Invalid embeddings request",
+        request_id: res.headers["x-request-id"]
+      }
+    });
+  });
+
+  it("returns 400 for unsupported model providers", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/embeddings",
+      payload: {
+        model: "anthropic/text-embedding-foo",
+        input: "hello"
+      }
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.headers["x-request-id"]).toBeTruthy();
+    expect(res.json()).toMatchObject({
+      error: {
+        code: "UNSUPPORTED_MODEL",
+        request_id: res.headers["x-request-id"]
+      }
+    });
+  });
+});

--- a/test/provider-adapters.test.ts
+++ b/test/provider-adapters.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  OpenAIStubProviderAdapter,
+  ProviderAdapterRegistry,
+  buildDefaultProviderAdapterRegistry
+} from "../src/provider-adapters.js";
+
+describe("provider adapter registry", () => {
+  it("resolves an embeddings adapter by model provider prefix", () => {
+    const registry = buildDefaultProviderAdapterRegistry();
+    const adapter = registry.resolveEmbeddingsAdapter("openai/text-embedding-3-small");
+
+    expect(adapter?.provider).toBe("openai");
+  });
+
+  it("returns null when no adapter supports the model", () => {
+    const registry = new ProviderAdapterRegistry();
+    registry.register(new OpenAIStubProviderAdapter());
+
+    expect(registry.resolveEmbeddingsAdapter("anthropic/claude-3-5-sonnet")).toBeNull();
+  });
+});
+
+describe("openai stub embeddings adapter", () => {
+  it("creates deterministic embedding rows for string and array input", async () => {
+    const adapter = new OpenAIStubProviderAdapter();
+
+    const single = await adapter.createEmbeddings({
+      model: "openai/text-embedding-3-small",
+      input: "hello"
+    });
+    const batch = await adapter.createEmbeddings({
+      model: "openai/text-embedding-3-small",
+      input: ["hello", "world"]
+    });
+
+    expect(single.data).toHaveLength(1);
+    expect(single.data[0]?.embedding).toHaveLength(3);
+    expect(batch.data.map((row) => row.index)).toEqual([0, 1]);
+    expect(batch.usage.total_tokens).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add provider adapter interfaces/registry with default OpenAI stub adapter
- implement POST /v1/embeddings stub with OpenAI-compatible response shape
- align embeddings error responses with request_id envelope and x-request-id header
- add route/unit tests and document M-002 milestone
- update OpenAPI contract and generated types for /v1/embeddings

## Verification
- make test
- make coverage
- make ci