### PR TITLE
feat: M-012 policies persistence abstraction + validation hardening

### DIFF
--- a/docs/milestones/M-012.md
+++ b/docs/milestones/M-012.md
@@ -1,0 +1,12 @@
+# M-012 Policies Persistence + Validation Hardening
+
+## Acceptance Criteria
+1. `/api/policies` uses a repository interface abstraction (in-memory implementation allowed for MVP).
+2. Request validation enforces required `weights` fields and rejects malformed `fallback_chain` and `constraints` using shared error envelope.
+3. Response shape remains OpenAPI-aligned.
+4. Tests cover create/list success plus multiple invalid payload scenarios.
+5. `make test`, `make coverage`, and `make ci` all pass.
+
+## Scope
+- In: repository abstraction + schema hardening.
+- Out: DB-backed policy persistence and runtime routing enforcement.

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import { InMemoryApiKeyStore, buildApiKeysListResponse, buildCreateApiKeyRespons
 import { buildChatCompletionsStubResponse } from "./chat-completions.js";
 import { buildEmbeddingsStubResponse } from "./embeddings.js";
 import { buildModelsListResponse } from "./models-catalog.js";
-import { InMemoryPolicyStore, createPolicySchema } from "./policies.js";
+import { InMemoryPolicyStore, type PolicyRepository, createPolicySchema } from "./policies.js";
 import { FixtureUsageRepository, buildUsageReportResponse } from "./usage-report.js";
 
 const healthzResponseSchema = z.object({
@@ -44,7 +44,7 @@ function requestErrorEnvelope(requestId: string, code: string, message: string, 
 
 type BuildAppOptions = {
   apiKeyStore?: InMemoryApiKeyStore;
-  policyStore?: InMemoryPolicyStore;
+  policyStore?: PolicyRepository;
   usageRepo?: FixtureUsageRepository;
 };
 

--- a/src/policies.ts
+++ b/src/policies.ts
@@ -22,7 +22,7 @@ export const createPolicySchema = z.object({
   weights: z.array(policyWeightSchema).min(1),
   fallback_chain: z.array(nonEmptyString).default([]),
   constraints: policyConstraintSchema.optional()
-});
+}).strict();
 
 export type CreatePolicyInput = z.infer<typeof createPolicySchema>;
 
@@ -39,7 +39,12 @@ export const policyRecordSchema = z.object({
 
 export type PolicyRecord = z.infer<typeof policyRecordSchema>;
 
-export class InMemoryPolicyStore {
+export interface PolicyRepository {
+  list(): PolicyRecord[];
+  create(input: CreatePolicyInput): PolicyRecord;
+}
+
+export class InMemoryPolicyStore implements PolicyRepository {
   private readonly items: PolicyRecord[];
   private nextId: number;
 

--- a/test/policies-routes.test.ts
+++ b/test/policies-routes.test.ts
@@ -91,4 +91,46 @@ describe("ui control-plane endpoints", () => {
       }
     });
   });
+
+  it("POST /api/policies rejects malformed weights fields", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/policies",
+      payload: {
+        name: "bad-weights",
+        route: "/v1/chat/completions",
+        weights: [{ provider: "", value: -1 }]
+      }
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Invalid policy payload"
+      }
+    });
+  });
+
+  it("POST /api/policies rejects malformed fallback_chain and constraints", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/policies",
+      payload: {
+        name: "bad-constraints",
+        route: "/v1/chat/completions",
+        weights: [{ provider: "openai", value: 1 }],
+        fallback_chain: [1],
+        constraints: { unsupported: true }
+      }
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Invalid policy payload"
+      }
+    });
+  });
 });


### PR DESCRIPTION
## What Changed
- add `PolicyRepository` abstraction and type app policy store dependency against interface
- harden `createPolicySchema` with strict object validation to reject unknown payload keys
- add additional `/api/policies` validation tests for malformed weights and fallback/constraints
- record acceptance criteria in `docs/milestones/M-012.md`

## Validation
- `make test`
- `make coverage`
- `make ci`

## Coverage Summary
- Global: 97.87% (>=85%)
- Key modules: 97.87% (>=80%)
