### PR TITLE
[M-016] Sync usage contract for provisional/finalized fields

### DIFF
--- a/docs/milestones/M-016.md
+++ b/docs/milestones/M-016.md
@@ -1,0 +1,25 @@
+# M-016 Control-plane usage/billing contract sync
+
+## Status
+- in_review
+
+## Scope
+- Align control-plane usage contract with provisional/finalized usage semantics.
+- Keep existing `/api/orgs/:orgId/usage` response backward-compatible.
+- Sync OpenAPI + generated API types/mocks + tests.
+
+## Acceptance Criteria
+- `/api/orgs/:orgId/usage` response includes UI-consumable contract fields for provisional/finalized state (`provisional`, `finalized_at`) and summary totals.
+- Contract-level tests cover both finalized and provisional usage records and validate envelope shape.
+- OpenAPI schema and generated client artifacts reflect the updated usage contract and remain backward-compatible.
+- `make test`, `make coverage`, and `make ci` all pass with coverage gates (`global >= 85%`, `key >= 80%`).
+
+## Validation Plan
+- `make test`
+- `make coverage`
+- `make ci`
+
+## Validation Result
+- `make test` PASS
+- `make coverage` PASS (global 96.82%, key 96.82%)
+- `make ci` PASS

--- a/openapi/mvp.yaml
+++ b/openapi/mvp.yaml
@@ -636,7 +636,7 @@ components:
     UsageBucket:
       type: object
       additionalProperties: false
-      required: [bucket, requests, input_tokens, output_tokens, total_tokens, cost_usd, platform_fee_usd]
+      required: [bucket, requests, input_tokens, output_tokens, total_tokens, cost_usd, platform_fee_usd, provisional, finalized_at]
       properties:
         bucket:
           type: string
@@ -658,10 +658,29 @@ components:
         platform_fee_usd:
           type: number
           minimum: 0
+        provisional:
+          type: boolean
+        finalized_at:
+          type: string
+          format: date-time
+          nullable: true
+    UsageSummary:
+      type: object
+      additionalProperties: false
+      required: [provisional, finalized_at, totals]
+      properties:
+        provisional:
+          type: boolean
+        finalized_at:
+          type: string
+          format: date-time
+          nullable: true
+        totals:
+          $ref: "#/components/schemas/UsageBucket"
     OrgUsageData:
       type: object
       additionalProperties: false
-      required: [org_id, from, to, group_by, provisional, finalized_at, totals, buckets]
+      required: [org_id, from, to, group_by, provisional, finalized_at, totals, summary, buckets]
       properties:
         org_id:
           type: string
@@ -682,6 +701,8 @@ components:
           nullable: true
         totals:
           $ref: "#/components/schemas/UsageBucket"
+        summary:
+          $ref: "#/components/schemas/UsageSummary"
         buckets:
           type: array
           items:

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -289,6 +289,15 @@ export interface components {
             total_tokens: number;
             cost_usd: number;
             platform_fee_usd: number;
+            provisional: boolean;
+            /** Format: date-time */
+            finalized_at: string | null;
+        };
+        UsageSummary: {
+            provisional: boolean;
+            /** Format: date-time */
+            finalized_at: string | null;
+            totals: components["schemas"]["UsageBucket"];
         };
         OrgUsageData: {
             org_id: string;
@@ -302,6 +311,7 @@ export interface components {
             /** Format: date-time */
             finalized_at: string | null;
             totals: components["schemas"]["UsageBucket"];
+            summary: components["schemas"]["UsageSummary"];
             buckets: components["schemas"]["UsageBucket"][];
         };
         OrgUsageResponse: {

--- a/src/usage-report.ts
+++ b/src/usage-report.ts
@@ -18,7 +18,9 @@ const usageBucketSchema = z.object({
   output_tokens: z.number().int().nonnegative(),
   total_tokens: z.number().int().nonnegative(),
   cost_usd: z.number().nonnegative(),
-  platform_fee_usd: z.number().nonnegative()
+  platform_fee_usd: z.number().nonnegative(),
+  provisional: z.boolean(),
+  finalized_at: z.string().datetime().nullable()
 });
 
 export const usageReportResponseSchema = z.object({
@@ -30,6 +32,11 @@ export const usageReportResponseSchema = z.object({
     provisional: z.boolean(),
     finalized_at: z.string().datetime().nullable(),
     totals: usageBucketSchema,
+    summary: z.object({
+      provisional: z.boolean(),
+      finalized_at: z.string().datetime().nullable(),
+      totals: usageBucketSchema
+    }),
     buckets: z.array(usageBucketSchema)
   }),
   meta: z.object({
@@ -41,6 +48,7 @@ type UsageEvent = {
   org_id: string;
   ts: string;
   model: string;
+  finalized_at: string | null;
   requests: number;
   input_tokens: number;
   output_tokens: number;
@@ -53,6 +61,7 @@ const FIXTURE_USAGE_EVENTS: UsageEvent[] = [
     org_id: "org_demo",
     ts: "2026-02-26T10:00:00.000Z",
     model: "openai/gpt-4.1-mini",
+    finalized_at: "2026-02-26T10:30:00.000Z",
     requests: 10,
     input_tokens: 1000,
     output_tokens: 400,
@@ -63,6 +72,7 @@ const FIXTURE_USAGE_EVENTS: UsageEvent[] = [
     org_id: "org_demo",
     ts: "2026-02-26T11:00:00.000Z",
     model: "openai/gpt-4.1-mini",
+    finalized_at: null,
     requests: 6,
     input_tokens: 700,
     output_tokens: 240,
@@ -73,6 +83,7 @@ const FIXTURE_USAGE_EVENTS: UsageEvent[] = [
     org_id: "org_demo",
     ts: "2026-02-26T11:00:00.000Z",
     model: "openai/text-embedding-3-small",
+    finalized_at: null,
     requests: 12,
     input_tokens: 900,
     output_tokens: 0,
@@ -89,7 +100,9 @@ function emptyBucket(bucket: string) {
     output_tokens: 0,
     total_tokens: 0,
     cost_usd: 0,
-    platform_fee_usd: 0
+    platform_fee_usd: 0,
+    provisional: false,
+    finalized_at: null
   };
 }
 
@@ -131,6 +144,13 @@ export function buildUsageReportResponse(
     bucket.total_tokens += event.input_tokens + event.output_tokens;
     bucket.cost_usd = roundMoney(bucket.cost_usd + event.cost_usd);
     bucket.platform_fee_usd = roundMoney(bucket.platform_fee_usd + event.platform_fee_usd);
+    if (event.finalized_at === null) {
+      bucket.provisional = true;
+      bucket.finalized_at = null;
+    } else if (!bucket.provisional) {
+      bucket.finalized_at =
+        bucket.finalized_at === null || event.finalized_at > bucket.finalized_at ? event.finalized_at : bucket.finalized_at;
+    }
     map.set(bucketKey, bucket);
   }
 
@@ -143,10 +163,22 @@ export function buildUsageReportResponse(
       output_tokens: acc.output_tokens + bucket.output_tokens,
       total_tokens: acc.total_tokens + bucket.total_tokens,
       cost_usd: roundMoney(acc.cost_usd + bucket.cost_usd),
-      platform_fee_usd: roundMoney(acc.platform_fee_usd + bucket.platform_fee_usd)
+      platform_fee_usd: roundMoney(acc.platform_fee_usd + bucket.platform_fee_usd),
+      provisional: acc.provisional || bucket.provisional,
+      finalized_at:
+        acc.provisional || bucket.provisional
+          ? null
+          : acc.finalized_at === null || (bucket.finalized_at !== null && bucket.finalized_at > acc.finalized_at)
+            ? bucket.finalized_at
+            : acc.finalized_at
     }),
     emptyBucket("total")
   );
+  const summary = {
+    provisional: totals.provisional,
+    finalized_at: totals.finalized_at,
+    totals
+  };
 
   return usageReportResponseSchema.parse({
     data: {
@@ -157,6 +189,7 @@ export function buildUsageReportResponse(
       provisional,
       finalized_at: finalizedAt,
       totals,
+      summary,
       buckets
     },
     meta: {

--- a/test/usage-report.test.ts
+++ b/test/usage-report.test.ts
@@ -41,6 +41,11 @@ describe("usage report aggregation", () => {
     expect(result.data.buckets).toHaveLength(2);
     expect(result.data.totals.requests).toBe(28);
     expect(result.data.totals.total_tokens).toBe(3240);
+    expect(result.data.totals.provisional).toBe(true);
+    expect(result.data.totals.finalized_at).toBeNull();
+    expect(result.data.summary.provisional).toBe(true);
+    expect(result.data.summary.finalized_at).toBeNull();
+    expect(result.data.summary.totals.total_tokens).toBe(3240);
   });
 
   it("marks future window as provisional", () => {

--- a/test/usage-route.test.ts
+++ b/test/usage-route.test.ts
@@ -30,6 +30,10 @@ describe("GET /api/orgs/:orgId/usage", () => {
     expect(parsed.data.finalized_at).toBe("2026-02-26T12:00:00.000Z");
     expect(parsed.data.buckets).toHaveLength(2);
     expect(parsed.data.totals.requests).toBe(28);
+    expect(parsed.data.totals.provisional).toBe(true);
+    expect(parsed.data.summary.provisional).toBe(true);
+    expect(parsed.data.summary.finalized_at).toBeNull();
+    expect(parsed.data.buckets.some((bucket) => bucket.provisional)).toBe(true);
   });
 
   it("returns 400 shared error envelope for invalid query params", async () => {


### PR DESCRIPTION
## What Changed
- Added usage contract fields `provisional` and `finalized_at` to usage buckets and totals.
- Added `summary` object (`provisional`, `finalized_at`, `totals`) for UI consumption while keeping existing `totals` for backward compatibility.
- Updated OpenAPI usage schemas and regenerated `src/generated/api-types.ts`.
- Extended usage report and usage route tests; updated milestone doc `docs/milestones/M-016.md`.

## Validation
- `make test`
- `make coverage`
- `make ci`

## Coverage Summary
- global: 96.82%
- key: 96.82%
