### PR TITLE
[M-006] Harden coverage gate parseability checks

### DIFF
--- a/docs/milestones/M-006.md
+++ b/docs/milestones/M-006.md
@@ -1,0 +1,28 @@
+# M-006 Replace Bootstrap CI Gates with Real Vitest + Coverage Thresholds
+
+## Status
+- in_review
+
+## Scope
+- Strengthen CI coverage gate reliability and parseability for automation.
+- Keep existing `make test`, `make coverage`, and `make ci` behavior backward-compatible.
+- Add focused gate tests for summary parsing aliases and stable output format lines.
+
+## Acceptance Criteria
+- `make test` executes real runtime checks including coverage gate tests.
+- Coverage gate parser accepts both `key_module=<pct>` and `key=<pct>` summary keys.
+- Coverage output keeps stable parseable summary lines:
+  - `[coverage] Global coverage: ...`
+  - `[coverage] Key module coverage: ...`
+- `make coverage` enforces thresholds (`global >=85%`, `key >=80%`).
+- `make ci` stays green on valid inputs and fails on threshold violations.
+
+## Validation Plan
+- `make test`
+- `make coverage`
+- `make ci`
+
+## Validation Result
+- `make test` PASS
+- `make coverage` PASS (global 96.55%, key 96.55%)
+- `make ci` PASS

--- a/tests/coverage_gate_test.sh
+++ b/tests/coverage_gate_test.sh
@@ -76,6 +76,28 @@ EOF
   assert_contains "$out" "[coverage] PASS"
 }
 
+test_summary_file_key_alias_pass() {
+  local tmp
+  tmp="$(mktemp)"
+  cat >"$tmp" <<EOF
+global=90
+key=81.25
+EOF
+  local out
+  out="$(run_case file-key-alias 0 env -i PATH="$PATH" HOME="${HOME:-/tmp}" COVERAGE_DISABLE_NPM=1 COVERAGE_SUMMARY_FILE="$tmp" bash "$COVERAGE_SCRIPT")"
+  rm -f "$tmp"
+  assert_contains "$out" "Global coverage: 90%"
+  assert_contains "$out" "Key module coverage: 81.25%"
+  assert_contains "$out" "[coverage] PASS"
+}
+
+test_output_summary_lines_stable() {
+  local out
+  out="$(run_case output-stable 0 env -i PATH="$PATH" HOME="${HOME:-/tmp}" COVERAGE_DISABLE_NPM=1 GLOBAL_COVERAGE=92 KEY_MODULE_COVERAGE=83 bash "$COVERAGE_SCRIPT")"
+  assert_contains "$out" "[coverage] Global coverage: 92% (threshold >=85%)"
+  assert_contains "$out" "[coverage] Key module coverage: 83% (threshold >=80%)"
+}
+
 test_summary_file_missing_key_fails() {
   local tmp
   tmp="$(mktemp)"
@@ -93,6 +115,8 @@ test_env_values_pass
 test_threshold_failure_fails
 test_invalid_numeric_fails
 test_summary_file_pass_and_parse
+test_summary_file_key_alias_pass
+test_output_summary_lines_stable
 test_summary_file_missing_key_fails
 
 echo "[test] coverage_gate_test.sh PASS"


### PR DESCRIPTION
## What Changed
- Added milestone doc `docs/milestones/M-006.md` with scope, acceptance criteria, and validation result.
- Expanded `tests/coverage_gate_test.sh` with parseability-focused cases:
  - summary file `key=<pct>` alias support
  - stable summary output line format checks for automation parsing
- Kept existing CI/test behavior backward-compatible.

## Validation
- `make test`
- `make coverage`
- `make ci`

## Coverage Summary
- global: 96.55%
- key: 96.55%
