### PR TITLE
[M-026] Add signed webhook delivery helpers (HMAC + replay guard)

### DIFF
--- a/docs/milestones/M-026.md
+++ b/docs/milestones/M-026.md
@@ -1,0 +1,26 @@
+# M-026 Signed Webhook Delivery (HMAC + Replay Guard)
+
+## Status
+- in_review
+
+## Scope
+- Add deterministic webhook signing helpers with HMAC-SHA256.
+- Add replay-window timestamp validation helper for inbound verification.
+- Add unit and integration tests for signature metadata and rejection cases.
+
+## Acceptance Criteria
+- Outgoing webhook helper includes signature header (`x-1router-webhook-signature`) and timestamp header (`x-1router-webhook-timestamp`).
+- Verification helper validates signature and rejects stale timestamps based on replay window.
+- Deterministic test vector exists for signature generation to prevent accidental algorithm drift.
+- Tests cover valid signature, invalid signature, stale timestamp, and signed delivery metadata.
+- `make test`, `make coverage`, and `make ci` pass.
+
+## Validation Plan
+- `make test`
+- `make coverage`
+- `make ci`
+
+## Validation Result
+- `make test` PASS
+- `make coverage` PASS (global 97.25%, key 97.25%)
+- `make ci` PASS

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,0 +1,70 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const WEBHOOK_SIGNATURE_HEADER = "x-1router-webhook-signature";
+export const WEBHOOK_TIMESTAMP_HEADER = "x-1router-webhook-timestamp";
+export const WEBHOOK_ID_HEADER = "x-1router-webhook-id";
+
+export type VerifyWebhookSignatureParams = {
+  secret: string;
+  timestamp: string;
+  signature: string;
+  body: string;
+  nowMs?: number;
+  replayWindowSeconds?: number;
+};
+
+export function buildWebhookSigningPayload(timestamp: string, body: string) {
+  return `${timestamp}.${body}`;
+}
+
+export function createWebhookSignature(secret: string, timestamp: string, body: string) {
+  return createHmac("sha256", secret).update(buildWebhookSigningPayload(timestamp, body)).digest("hex");
+}
+
+export function buildSignedWebhookHeaders(params: {
+  secret: string;
+  body: string;
+  timestamp?: string;
+  deliveryId: string;
+}) {
+  const timestamp = params.timestamp ?? Math.floor(Date.now() / 1000).toString();
+  const signature = createWebhookSignature(params.secret, timestamp, params.body);
+  return {
+    [WEBHOOK_ID_HEADER]: params.deliveryId,
+    [WEBHOOK_TIMESTAMP_HEADER]: timestamp,
+    [WEBHOOK_SIGNATURE_HEADER]: `v1=${signature}`
+  };
+}
+
+export function isWebhookTimestampFresh(timestamp: string, nowMs = Date.now(), replayWindowSeconds = 300) {
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts) || ts <= 0) return false;
+  return Math.abs(nowMs - ts * 1000) <= replayWindowSeconds * 1000;
+}
+
+function timingSafeEqualHex(a: string, b: string) {
+  const aBuf = Buffer.from(a, "hex");
+  const bBuf = Buffer.from(b, "hex");
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+export function verifyWebhookSignature(params: VerifyWebhookSignatureParams) {
+  const replayWindowSeconds = params.replayWindowSeconds ?? 300;
+  const nowMs = params.nowMs ?? Date.now();
+  if (!isWebhookTimestampFresh(params.timestamp, nowMs, replayWindowSeconds)) {
+    return { ok: false as const, error: "STALE_TIMESTAMP" as const };
+  }
+
+  const received = params.signature.startsWith("v1=") ? params.signature.slice(3) : params.signature;
+  if (!/^[0-9a-f]{64}$/i.test(received)) {
+    return { ok: false as const, error: "INVALID_SIGNATURE_FORMAT" as const };
+  }
+
+  const expected = createWebhookSignature(params.secret, params.timestamp, params.body);
+  if (!timingSafeEqualHex(expected, received.toLowerCase())) {
+    return { ok: false as const, error: "SIGNATURE_MISMATCH" as const };
+  }
+
+  return { ok: true as const };
+}

--- a/test/webhook-delivery-route.test.ts
+++ b/test/webhook-delivery-route.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildApp } from "../src/app.js";
+import { WEBHOOK_ID_HEADER, WEBHOOK_SIGNATURE_HEADER, WEBHOOK_TIMESTAMP_HEADER, buildSignedWebhookHeaders } from "../src/webhooks.js";
+
+describe("webhook delivery integration", () => {
+  const app = buildApp({
+    registerRoutes(instance) {
+      instance.post("/internal/webhook-test-delivery", async (_request, reply) => {
+        const body = JSON.stringify({ event: "usage.finalized", org_id: "org_demo", total_tokens: 1200 });
+        const headers = buildSignedWebhookHeaders({
+          secret: "whsec_test_123",
+          timestamp: "1700000000",
+          deliveryId: "wh_001",
+          body
+        });
+        return reply.send({ body, headers });
+      });
+    }
+  });
+
+  beforeAll(async () => {
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("includes signature metadata on delivery payload", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/internal/webhook-test-delivery"
+    });
+
+    expect(res.statusCode).toBe(200);
+    const payload = res.json() as { body: string; headers: Record<string, string> };
+    expect(payload.headers[WEBHOOK_ID_HEADER]).toBe("wh_001");
+    expect(payload.headers[WEBHOOK_TIMESTAMP_HEADER]).toBe("1700000000");
+    expect(payload.headers[WEBHOOK_SIGNATURE_HEADER]).toBe(
+      "v1=dfb3bd067f300ae5129b954d5fbcada23f3353ae5df8656fa1c067809e3fdbc4"
+    );
+  });
+});

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  WEBHOOK_ID_HEADER,
+  WEBHOOK_SIGNATURE_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+  buildSignedWebhookHeaders,
+  createWebhookSignature,
+  isWebhookTimestampFresh,
+  verifyWebhookSignature
+} from "../src/webhooks.js";
+
+describe("webhook signing", () => {
+  it("matches deterministic signature test vector", () => {
+    const signature = createWebhookSignature("whsec_test_123", "1700000000", "{\"event\":\"usage.finalized\"}");
+    expect(signature).toBe("695832fa9df3c64e22994f5f4f0d385894b06f1cf27444e6bb4425869a500ab8");
+  });
+
+  it("builds signed webhook headers", () => {
+    const headers = buildSignedWebhookHeaders({
+      secret: "whsec_test_123",
+      timestamp: "1700000000",
+      body: "{\"event\":\"usage.finalized\"}",
+      deliveryId: "wh_001"
+    });
+
+    expect(headers[WEBHOOK_ID_HEADER]).toBe("wh_001");
+    expect(headers[WEBHOOK_TIMESTAMP_HEADER]).toBe("1700000000");
+    expect(headers[WEBHOOK_SIGNATURE_HEADER]).toBe(
+      "v1=695832fa9df3c64e22994f5f4f0d385894b06f1cf27444e6bb4425869a500ab8"
+    );
+  });
+});
+
+describe("webhook replay guard and verification", () => {
+  it("verifies valid signature", () => {
+    const result = verifyWebhookSignature({
+      secret: "whsec_test_123",
+      timestamp: "1700000000",
+      signature: "v1=695832fa9df3c64e22994f5f4f0d385894b06f1cf27444e6bb4425869a500ab8",
+      body: "{\"event\":\"usage.finalized\"}",
+      nowMs: 1700000000 * 1000,
+      replayWindowSeconds: 300
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects invalid signature", () => {
+    const result = verifyWebhookSignature({
+      secret: "whsec_test_123",
+      timestamp: "1700000000",
+      signature: "v1=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      body: "{\"event\":\"usage.finalized\"}",
+      nowMs: 1700000000 * 1000,
+      replayWindowSeconds: 300
+    });
+    expect(result).toEqual({ ok: false, error: "SIGNATURE_MISMATCH" });
+  });
+
+  it("rejects stale timestamp", () => {
+    const result = verifyWebhookSignature({
+      secret: "whsec_test_123",
+      timestamp: "1700000000",
+      signature: "v1=695832fa9df3c64e22994f5f4f0d385894b06f1cf27444e6bb4425869a500ab8",
+      body: "{\"event\":\"usage.finalized\"}",
+      nowMs: 1700000900 * 1000,
+      replayWindowSeconds: 300
+    });
+    expect(result).toEqual({ ok: false, error: "STALE_TIMESTAMP" });
+  });
+
+  it("checks replay window helper", () => {
+    expect(isWebhookTimestampFresh("1700000000", 1700000100 * 1000, 120)).toBe(true);
+    expect(isWebhookTimestampFresh("1700000000", 1700000500 * 1000, 120)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What Changed
- Added `src/webhooks.ts` for webhook signing and verification utilities:
  - HMAC-SHA256 signature generation
  - signed headers builder (`x-1router-webhook-signature`, `x-1router-webhook-timestamp`, `x-1router-webhook-id`)
  - replay-window timestamp freshness helper
  - signature verification with stale timestamp and mismatch detection
- Added deterministic signature vector tests in `test/webhooks.test.ts` covering:
  - valid signature
  - invalid signature
  - stale timestamp
- Added integration test `test/webhook-delivery-route.test.ts` that validates signature metadata is present in a delivery payload.
- Added milestone doc `docs/milestones/M-026.md` with acceptance criteria and validation result.

## Validation
- `make test`
- `make coverage`
- `make ci`

## Coverage Summary
- global: 97.25%
- key: 97.25%
