### PR TITLE
[M-023] Implement usage finalization job (provisional -> finalized)

### DIFF
--- a/docs/milestones/M-023.md
+++ b/docs/milestones/M-023.md
@@ -1,0 +1,21 @@
+# M-023 Usage Finalization Job (provisional -> finalized)
+
+## Status
+- in_review
+
+## Scope
+- Add a usage finalization job entrypoint with configurable reconciliation delay.
+- Mark eligible provisional usage rows as finalized with `finalized_at`.
+- Guarantee rerun idempotency (no repeated state mutation).
+
+## Acceptance Criteria
+- Job/service entrypoint exists and accepts reconciliation delay configuration.
+- Eligible provisional rows transition to finalized and receive correct `finalized_at`.
+- Rerun is no-op for already finalized rows.
+- Tests cover eligible transition, no-op rerun, and mixed provisional/finalized dataset.
+- `make test`, `make coverage`, `make ci` all pass.
+
+## Validation Plan
+- `make test`
+- `make coverage`
+- `make ci`

--- a/src/usage-report.ts
+++ b/src/usage-report.ts
@@ -44,7 +44,7 @@ export const usageReportResponseSchema = z.object({
   })
 });
 
-type UsageEvent = {
+export type UsageEvent = {
   org_id: string;
   ts: string;
   model: string;
@@ -122,6 +122,40 @@ export class FixtureUsageRepository {
       return event.org_id === orgId && ts >= from && ts < to;
     });
   }
+
+  finalizeEligible(params: { finalizeBeforeIso: string; finalizedAtIso: string }) {
+    const cutoff = new Date(params.finalizeBeforeIso).getTime();
+    let finalized = 0;
+
+    for (const event of this.events) {
+      const eventTs = new Date(event.ts).getTime();
+      if (event.finalized_at !== null || eventTs >= cutoff) continue;
+      event.finalized_at = params.finalizedAtIso;
+      finalized += 1;
+    }
+
+    return {
+      scanned: this.events.length,
+      finalized,
+      finalized_at: params.finalizedAtIso
+    };
+  }
+}
+
+export function runUsageFinalizationJob(
+  repo: FixtureUsageRepository,
+  params: { nowIso: string; reconciliationDelayMinutes: number }
+) {
+  const cutoffMs = new Date(params.nowIso).getTime() - params.reconciliationDelayMinutes * 60 * 1000;
+  const cutoffIso = new Date(cutoffMs).toISOString();
+
+  return {
+    cutoff_iso: cutoffIso,
+    ...repo.finalizeEligible({
+      finalizeBeforeIso: cutoffIso,
+      finalizedAtIso: params.nowIso
+    })
+  };
 }
 
 export function buildUsageReportResponse(

--- a/test/usage-report.test.ts
+++ b/test/usage-report.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { FixtureUsageRepository, buildUsageReportResponse, usageQuerySchema } from "../src/usage-report.js";
+import {
+  FixtureUsageRepository,
+  buildUsageReportResponse,
+  runUsageFinalizationJob,
+  usageQuerySchema,
+  type UsageEvent
+} from "../src/usage-report.js";
 
 describe("usage report query validation", () => {
   it("accepts valid params and defaults group_by", () => {
@@ -62,5 +68,105 @@ describe("usage report aggregation", () => {
 
     expect(result.data.provisional).toBe(true);
     expect(result.data.finalized_at).toBeNull();
+  });
+});
+
+describe("usage finalization job", () => {
+  const mixedEvents: UsageEvent[] = [
+    {
+      org_id: "org_demo",
+      ts: "2026-02-26T10:00:00.000Z",
+      model: "openai/gpt-4.1-mini",
+      finalized_at: null,
+      requests: 5,
+      input_tokens: 500,
+      output_tokens: 200,
+      cost_usd: 0.05,
+      platform_fee_usd: 0.01
+    },
+    {
+      org_id: "org_demo",
+      ts: "2026-02-26T11:30:00.000Z",
+      model: "openai/gpt-4.1-mini",
+      finalized_at: null,
+      requests: 3,
+      input_tokens: 300,
+      output_tokens: 120,
+      cost_usd: 0.03,
+      platform_fee_usd: 0.006
+    },
+    {
+      org_id: "org_demo",
+      ts: "2026-02-26T09:00:00.000Z",
+      model: "openai/text-embedding-3-small",
+      finalized_at: "2026-02-26T09:30:00.000Z",
+      requests: 4,
+      input_tokens: 240,
+      output_tokens: 0,
+      cost_usd: 0.01,
+      platform_fee_usd: 0.002
+    }
+  ];
+
+  it("finalizes eligible provisional usage records", () => {
+    const repo = new FixtureUsageRepository(structuredClone(mixedEvents));
+    const result = runUsageFinalizationJob(repo, {
+      nowIso: "2026-02-26T12:00:00.000Z",
+      reconciliationDelayMinutes: 60
+    });
+
+    expect(result.cutoff_iso).toBe("2026-02-26T11:00:00.000Z");
+    expect(result.finalized).toBe(1);
+
+    const report = buildUsageReportResponse(repo, {
+      orgId: "org_demo",
+      requestId: "req_finalized_1",
+      query: {
+        from: "2026-02-26T09:00:00.000Z",
+        to: "2026-02-26T12:00:00.000Z",
+        group_by: "hour"
+      }
+    });
+    const finalizedBucket = report.data.buckets.find((bucket) => bucket.bucket === "2026-02-26T10:00:00.000Z");
+    expect(finalizedBucket?.provisional).toBe(false);
+    expect(finalizedBucket?.finalized_at).toBe("2026-02-26T12:00:00.000Z");
+  });
+
+  it("is idempotent on rerun and makes no-op updates", () => {
+    const repo = new FixtureUsageRepository(structuredClone(mixedEvents));
+    const first = runUsageFinalizationJob(repo, {
+      nowIso: "2026-02-26T12:00:00.000Z",
+      reconciliationDelayMinutes: 60
+    });
+    const second = runUsageFinalizationJob(repo, {
+      nowIso: "2026-02-26T12:05:00.000Z",
+      reconciliationDelayMinutes: 60
+    });
+
+    expect(first.finalized).toBe(1);
+    expect(second.finalized).toBe(0);
+  });
+
+  it("keeps mixed dataset semantics (new provisional remains provisional)", () => {
+    const repo = new FixtureUsageRepository(structuredClone(mixedEvents));
+    runUsageFinalizationJob(repo, {
+      nowIso: "2026-02-26T12:00:00.000Z",
+      reconciliationDelayMinutes: 60
+    });
+
+    const report = buildUsageReportResponse(repo, {
+      orgId: "org_demo",
+      requestId: "req_finalized_2",
+      query: {
+        from: "2026-02-26T09:00:00.000Z",
+        to: "2026-02-26T12:00:00.000Z",
+        group_by: "hour"
+      }
+    });
+
+    const provisionalBucket = report.data.buckets.find((bucket) => bucket.bucket === "2026-02-26T11:00:00.000Z");
+    expect(provisionalBucket?.provisional).toBe(true);
+    expect(provisionalBucket?.finalized_at).toBeNull();
+    expect(report.data.totals.provisional).toBe(true);
   });
 });


### PR DESCRIPTION
## What Changed
- Added a usage finalization service entrypoint `runUsageFinalizationJob(...)` with configurable reconciliation delay.
- Added repository mutation method `finalizeEligible(...)` to transition eligible provisional records to finalized and set `finalized_at`.
- Ensured rerun idempotency by only finalizing rows with `finalized_at = null` and outside the cutoff window.
- Added milestone document `docs/milestones/M-023.md`.

## Validation
- `make test`
- `make coverage`
- `make ci`

## Coverage Summary
- global: 97.42%
- key: 97.42%
