### PR TITLE
[M-024] Add budget threshold webhooks (80% and 100%)

### DIFF
--- a/docs/milestones/M-024.md
+++ b/docs/milestones/M-024.md
@@ -1,0 +1,21 @@
+# M-024 Budget Threshold Webhooks (80% / 100%)
+
+## Status
+- in_review
+
+## Scope
+- Emit budget threshold webhook events at 80% and 100% spend levels.
+- Deduplicate threshold notifications within the same configured time window.
+- Ensure payload contract and signature metadata are complete for delivery.
+
+## Acceptance Criteria
+- Threshold crossings emit webhook deliveries for `80%` and `100%` as applicable.
+- Dedup logic prevents repeated notifications for the same threshold in the same window.
+- Payload includes org/project identifiers, budget, current spend, and request timestamp.
+- Tests cover threshold crossing, duplicate suppression, and payload contract validation.
+- `make test`, `make coverage`, `make ci` all pass.
+
+## Validation Plan
+- `make test`
+- `make coverage`
+- `make ci`

--- a/src/budget-threshold-webhooks.ts
+++ b/src/budget-threshold-webhooks.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import { buildSignedWebhookHeaders } from "./webhooks.js";
+
+const BUDGET_THRESHOLDS = [0.8, 1] as const;
+
+export const budgetThresholdWebhookPayloadSchema = z.object({
+  event_id: z.string().min(1),
+  event_type: z.literal("budget.threshold_reached"),
+  org_id: z.string().min(1),
+  project_id: z.string().min(1),
+  threshold_pct: z.union([z.literal(80), z.literal(100)]),
+  budget_usd: z.number().positive(),
+  current_spend_usd: z.number().nonnegative(),
+  request_timestamp: z.string().datetime()
+});
+
+type BudgetThresholdWebhookPayload = z.infer<typeof budgetThresholdWebhookPayloadSchema>;
+
+type DedupRecord = {
+  window_key: string;
+};
+
+export class InMemoryBudgetWebhookDedupStore {
+  private readonly records = new Map<string, DedupRecord>();
+
+  seen(key: string, windowKey: string) {
+    const record = this.records.get(key);
+    return record?.window_key === windowKey;
+  }
+
+  mark(key: string, windowKey: string) {
+    this.records.set(key, { window_key: windowKey });
+  }
+}
+
+function buildWindowKey(observedAtIso: string, windowMinutes: number) {
+  const observedMs = new Date(observedAtIso).getTime();
+  const windowMs = windowMinutes * 60 * 1000;
+  const bucket = Math.floor(observedMs / windowMs);
+  return `${bucket}`;
+}
+
+function buildEventId(params: {
+  orgId: string;
+  projectId: string;
+  thresholdPct: 80 | 100;
+  windowKey: string;
+}) {
+  return `evt_budget_${params.orgId}_${params.projectId}_${params.thresholdPct}_${params.windowKey}`;
+}
+
+export function emitBudgetThresholdWebhooks(
+  dedupStore: InMemoryBudgetWebhookDedupStore,
+  params: {
+    orgId: string;
+    projectId: string;
+    budgetUsd: number;
+    currentSpendUsd: number;
+    requestTimestamp: string;
+    webhookSecret: string;
+    windowMinutes?: number;
+  }
+) {
+  const windowMinutes = params.windowMinutes ?? 60;
+  const windowKey = buildWindowKey(params.requestTimestamp, windowMinutes);
+  const deliveries: Array<{ payload: BudgetThresholdWebhookPayload; headers: Record<string, string> }> = [];
+
+  for (const threshold of BUDGET_THRESHOLDS) {
+    if (params.currentSpendUsd < params.budgetUsd * threshold) continue;
+
+    const thresholdPct = threshold === 0.8 ? 80 : 100;
+    const dedupKey = `${params.orgId}:${params.projectId}:${thresholdPct}`;
+    if (dedupStore.seen(dedupKey, windowKey)) continue;
+
+    dedupStore.mark(dedupKey, windowKey);
+    const eventId = buildEventId({
+      orgId: params.orgId,
+      projectId: params.projectId,
+      thresholdPct,
+      windowKey
+    });
+    const payload = budgetThresholdWebhookPayloadSchema.parse({
+      event_id: eventId,
+      event_type: "budget.threshold_reached",
+      org_id: params.orgId,
+      project_id: params.projectId,
+      threshold_pct: thresholdPct,
+      budget_usd: params.budgetUsd,
+      current_spend_usd: params.currentSpendUsd,
+      request_timestamp: params.requestTimestamp
+    });
+    const body = JSON.stringify(payload);
+    deliveries.push({
+      payload,
+      headers: buildSignedWebhookHeaders({
+        secret: params.webhookSecret,
+        body,
+        timestamp: Math.floor(new Date(params.requestTimestamp).getTime() / 1000).toString(),
+        deliveryId: eventId
+      })
+    });
+  }
+
+  return deliveries;
+}

--- a/test/budget-threshold-webhooks.test.ts
+++ b/test/budget-threshold-webhooks.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  InMemoryBudgetWebhookDedupStore,
+  budgetThresholdWebhookPayloadSchema,
+  emitBudgetThresholdWebhooks
+} from "../src/budget-threshold-webhooks.js";
+import { WEBHOOK_ID_HEADER, WEBHOOK_SIGNATURE_HEADER, WEBHOOK_TIMESTAMP_HEADER } from "../src/webhooks.js";
+
+describe("budget threshold webhooks", () => {
+  it("emits 80% and 100% threshold events when budget spend reaches 100%", () => {
+    const store = new InMemoryBudgetWebhookDedupStore();
+    const deliveries = emitBudgetThresholdWebhooks(store, {
+      orgId: "org_demo",
+      projectId: "proj_demo",
+      budgetUsd: 100,
+      currentSpendUsd: 100,
+      requestTimestamp: "2026-02-27T02:00:00.000Z",
+      webhookSecret: "whsec_budget_test"
+    });
+
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries.map((item) => item.payload.threshold_pct)).toEqual([80, 100]);
+  });
+
+  it("deduplicates same threshold within the same window", () => {
+    const store = new InMemoryBudgetWebhookDedupStore();
+    const first = emitBudgetThresholdWebhooks(store, {
+      orgId: "org_demo",
+      projectId: "proj_demo",
+      budgetUsd: 100,
+      currentSpendUsd: 85,
+      requestTimestamp: "2026-02-27T02:05:00.000Z",
+      webhookSecret: "whsec_budget_test",
+      windowMinutes: 60
+    });
+    const second = emitBudgetThresholdWebhooks(store, {
+      orgId: "org_demo",
+      projectId: "proj_demo",
+      budgetUsd: 100,
+      currentSpendUsd: 95,
+      requestTimestamp: "2026-02-27T02:35:00.000Z",
+      webhookSecret: "whsec_budget_test",
+      windowMinutes: 60
+    });
+
+    expect(first).toHaveLength(1);
+    expect(first[0]?.payload.threshold_pct).toBe(80);
+    expect(second).toHaveLength(0);
+  });
+
+  it("returns full payload contract and signed headers", () => {
+    const store = new InMemoryBudgetWebhookDedupStore();
+    const deliveries = emitBudgetThresholdWebhooks(store, {
+      orgId: "org_demo",
+      projectId: "proj_demo",
+      budgetUsd: 100,
+      currentSpendUsd: 85,
+      requestTimestamp: "2026-02-27T02:10:00.000Z",
+      webhookSecret: "whsec_budget_test"
+    });
+
+    expect(deliveries).toHaveLength(1);
+    const event = deliveries[0];
+    const payload = budgetThresholdWebhookPayloadSchema.parse(event?.payload);
+    expect(payload.org_id).toBe("org_demo");
+    expect(payload.project_id).toBe("proj_demo");
+    expect(payload.threshold_pct).toBe(80);
+    expect(payload.budget_usd).toBe(100);
+    expect(payload.current_spend_usd).toBe(85);
+    expect(payload.request_timestamp).toBe("2026-02-27T02:10:00.000Z");
+    expect(event?.headers[WEBHOOK_ID_HEADER]).toBe(payload.event_id);
+    expect(event?.headers[WEBHOOK_TIMESTAMP_HEADER]).toBe("1772158200");
+    expect(event?.headers[WEBHOOK_SIGNATURE_HEADER]?.startsWith("v1=")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What Changed
- Added budget threshold webhook evaluator `emitBudgetThresholdWebhooks(...)` for 80% and 100% budget milestones.
- Added in-memory dedup store to prevent repeated emits for the same threshold inside a dedup window.
- Added full webhook payload contract schema with org/project, budget, spend, threshold, and request timestamp.
- Reused webhook signing helper to produce signed delivery headers per event.
- Added milestone doc `docs/milestones/M-024.md`.

## Validation
- `make test`
- `make coverage`
- `make ci`

## Coverage Summary
- global: 97.51%
- key: 97.51%
