### PR TITLE
[M-034] Add issue-state transition guard for worker/merger automation

### DIFF
--- a/docs/milestones/M-034.md
+++ b/docs/milestones/M-034.md
@@ -1,0 +1,21 @@
+# M-034 CI Guard for Branch Naming and Issue-State Transition
+
+## Status
+- in_review
+
+## Scope
+- Add reusable issue-state transition validator script for automation.
+- Keep branch format guard (`codex/<lane>-<milestone>-<slug>`) in CI tooling.
+- Integrate transition validation into worker/merger scripts.
+
+## Acceptance Criteria
+- Branch format validation script enforces `codex/<lane>-<milestone>-<slug>`.
+- Issue-state helper validates `ready -> in_progress -> done` transitions.
+- Automation scripts use the transition helper in claim/merge paths.
+- Tests cover valid and invalid branch/label transition cases.
+- `make test`, `make coverage`, and `make ci` pass.
+
+## Validation Plan
+- `make test`
+- `make coverage`
+- `make ci`

--- a/scripts/agent/check-issue-transition.sh
+++ b/scripts/agent/check-issue-transition.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FROM="${1:?from state required (ready|in_progress|done|blocked)}"
+TO="${2:?to state required (ready|in_progress|done|blocked)}"
+
+case "$FROM" in
+  ready)
+    [[ "$TO" == "in_progress" ]] || {
+      echo "[issue-transition] FAIL: only ready -> in_progress is allowed" >&2
+      exit 1
+    }
+    ;;
+  in_progress)
+    [[ "$TO" == "done" || "$TO" == "blocked" ]] || {
+      echo "[issue-transition] FAIL: only in_progress -> done|blocked is allowed" >&2
+      exit 1
+    }
+    ;;
+  blocked)
+    [[ "$TO" == "in_progress" ]] || {
+      echo "[issue-transition] FAIL: only blocked -> in_progress is allowed" >&2
+      exit 1
+    }
+    ;;
+  done)
+    echo "[issue-transition] FAIL: done is terminal" >&2
+    exit 1
+    ;;
+  *)
+    echo "[issue-transition] FAIL: unknown state '$FROM'" >&2
+    exit 1
+    ;;
+esac
+
+echo "[issue-transition] PASS: ${FROM} -> ${TO}"

--- a/scripts/agent/claim-issue.sh
+++ b/scripts/agent/claim-issue.sh
@@ -16,6 +16,18 @@ if [[ -n "$MILESTONE_ID" || -n "$LANE" ]]; then
   "$SCRIPT_DIR/check-branch-name.sh" "$LANE" "$MILESTONE_ID"
 fi
 
+LABELS="$(gh issue view "$ISSUE" --json labels --jq '.labels[].name' || true)"
+if grep -qx "ready" <<<"$LABELS"; then
+  "$SCRIPT_DIR/check-issue-transition.sh" ready in_progress
+elif grep -qx "blocked" <<<"$LABELS"; then
+  "$SCRIPT_DIR/check-issue-transition.sh" blocked in_progress
+elif grep -qx "in_progress" <<<"$LABELS"; then
+  echo "[issue-transition] INFO: issue already in_progress"
+else
+  echo "[issue-transition] FAIL: expected label ready|blocked|in_progress before claim" >&2
+  exit 1
+fi
+
 gh issue edit "$ISSUE" --add-label "in_progress" --remove-label "ready" >/dev/null || true
 
 if [[ "$ASSIGNEE" != "@me" ]]; then

--- a/scripts/agent/merge-pr.sh
+++ b/scripts/agent/merge-pr.sh
@@ -9,6 +9,16 @@ gh pr merge "$PR" --squash --delete-branch
 
 ISSUES="$(gh pr view "$PR" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' || true)"
 for ISSUE in $ISSUES; do
+  LABELS="$(gh issue view "$ISSUE" --json labels --jq '.labels[].name' || true)"
+  if grep -qx "in_progress" <<<"$LABELS"; then
+    "$SCRIPT_DIR/check-issue-transition.sh" in_progress done
+  elif grep -qx "done" <<<"$LABELS"; then
+    echo "[issue-transition] INFO: issue already done"
+  else
+    echo "[issue-transition] FAIL: issue #$ISSUE missing in_progress before close" >&2
+    exit 1
+  fi
+
   gh issue edit "$ISSUE" --add-label "done" --remove-label "in_progress" --remove-label "ready" --remove-label "review" --remove-label "blocked" >/dev/null || true
   gh issue comment "$ISSUE" --body "Merged via automation. Milestone completed and gates passed (\`make test\`, \`make coverage\`, \`make ci\`)." || true
 done

--- a/tests/agent_state_consistency_test.sh
+++ b/tests/agent_state_consistency_test.sh
@@ -57,8 +57,21 @@ test_merge_script_removes_ready_label() {
   assert_contains "$out" "--remove-label \"ready\""
 }
 
+test_issue_transition_validator() {
+  local out
+  out="$(run_case 0 bash "$ROOT_DIR/scripts/agent/check-issue-transition.sh" ready in_progress)"
+  assert_contains "$out" "[issue-transition] PASS"
+
+  out="$(run_case 0 bash "$ROOT_DIR/scripts/agent/check-issue-transition.sh" in_progress done)"
+  assert_contains "$out" "[issue-transition] PASS"
+
+  out="$(run_case 1 bash "$ROOT_DIR/scripts/agent/check-issue-transition.sh" ready done)"
+  assert_contains "$out" "only ready -> in_progress is allowed"
+}
+
 test_branch_naming_validator
 test_blocked_helper_dry_run
 test_merge_script_removes_ready_label
+test_issue_transition_validator
 
 echo "[test] agent_state_consistency_test.sh PASS"


### PR DESCRIPTION
## What Changed
- Added `scripts/agent/check-issue-transition.sh` to validate allowed label transitions (`ready -> in_progress -> done`) with blocked-path support (`in_progress -> blocked`, `blocked -> in_progress`).
- Integrated transition checks into:
  - `scripts/agent/claim-issue.sh` before moving issues into `in_progress`
  - `scripts/agent/merge-pr.sh` before moving closing issues to `done`
- Extended `tests/agent_state_consistency_test.sh` with transition validator pass/fail cases.
- Added milestone doc `docs/milestones/M-034.md`.

## Validation
- `make test`
- `make coverage`
- `make ci`

## Coverage Summary
- global: 94.65%
- key: 94.65%
